### PR TITLE
Updated required Vue2-Dropzone package to latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ export default {
 
 See [the vue-dropzone docs](https://rowanwins.github.io/vue-dropzone/docs/dist/index.html#/props) for futher configuration information.
 
+Now includes function call for aws s3 signing url
+
 ## Common issues and solutions
 
  * [Importing styles doesn't work with PostCSS out-of-the-box](https://github.com/Etheryte/nuxt-dropzone/issues/3)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ export default {
 
 See [the vue-dropzone docs](https://rowanwins.github.io/vue-dropzone/docs/dist/index.html#/props) for futher configuration information.
 
-Now includes function call for aws s3 signing url
+Now includes function call for aws s3 signing url.
 
 ## Common issues and solutions
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-dropzone",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Nuxt SSR-compatible Dropzone component",
   "main": "index.js",
   "repository": {
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/Etheryte/nuxt-dropzone#readme",
   "dependencies": {
-    "vue2-dropzone": "3.0.3"
+    "vue2-dropzone": "3.5.2"
   },
   "files": [
     "dropzone.css"


### PR DESCRIPTION
Allows adding parameters to AWS S3 Signing URL via an anonymous function, meaning you can send the filename of the original object to your endpoint and set the key in S3 #7 